### PR TITLE
 Refactor/#101: 반려동물 수정 로직 도메인 메서드로 위임 및 중복 제거

### DIFF
--- a/src/main/java/com/petmatz/api/pet/PetController.java
+++ b/src/main/java/com/petmatz/api/pet/PetController.java
@@ -54,7 +54,7 @@ public class PetController {
     @PutMapping("/{id}")
     @Operation(summary = "반려동물 정보 수정", description = "기존 반려동물 정보를 수정합니다.")
     @Parameter(name = "id", description = "반려동물 ID", example = "1")
-    public ResponseEntity<Response<PetUpdateResponse>> updatePet(@PathVariable Long id, @RequestBody PetRequest updatedRequest) {
+    public ResponseEntity<Response<PetUpdateResponse>> updatePet(@PathVariable Long id, @RequestBody PetRequest updatedRequest) throws MalformedURLException {
         User user = getAuthenticatedUser();
         PetServiceDto updatedServiceDto = PetServiceDto.of(updatedRequest);
         PetUpdateResponse petUpdateResponse = petServiceImpl.updatePet(id, user, updatedServiceDto);

--- a/src/main/java/com/petmatz/domain/pet/Pet.java
+++ b/src/main/java/com/petmatz/domain/pet/Pet.java
@@ -1,6 +1,7 @@
 package com.petmatz.domain.pet;
 
 import com.petmatz.domain.global.BaseEntity;
+import com.petmatz.domain.pet.dto.PetServiceDto;
 import com.petmatz.domain.petmission.entity.PetToPetMissionEntity;
 import com.petmatz.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -72,5 +73,36 @@ public class Pet extends BaseEntity {
         user = null;
     }
 
+    public static Pet createFromDto(User user, PetServiceDto dto, String profileImg) {
+        return Pet.builder()
+                .user(user)
+                .dogRegNo(dto.dogRegNo())
+                .petName(dto.petName())
+                .breed(dto.breed())
+                .gender(Gender.fromString(dto.gender()))
+                .neuterYn(dto.neuterYn())
+                .size(Size.fromString(dto.size()))
+                .age(dto.age())
+                .temperament(dto.temperament())
+                .preferredWalkingLocation(dto.preferredWalkingLocation())
+                .profileImg(profileImg)
+                .comment(dto.comment())
+                .build();
+    }
+
+    public void updateFromDto(PetServiceDto dto, String profileImg) {
+        this.petName = dto.petName() != null ? dto.petName() : this.petName;
+        this.breed = dto.breed() != null ? dto.breed() : this.breed;
+        this.gender = dto.gender() != null ? Gender.fromString(dto.gender()) : this.gender;
+        this.neuterYn = dto.neuterYn() != null ? dto.neuterYn() : this.neuterYn;
+        this.size = dto.size() != null ? Size.fromString(dto.size()) : this.size;
+        this.age = dto.age() != null ? dto.age() : this.age;
+        this.temperament = dto.temperament() != null ? dto.temperament() : this.temperament;
+        this.preferredWalkingLocation = dto.preferredWalkingLocation() != null ? dto.preferredWalkingLocation() : this.preferredWalkingLocation;
+        this.profileImg = profileImg != null ? profileImg : this.profileImg;
+        this.comment = dto.comment() != null ? dto.comment() : this.comment;
+    }
 }
+
+
 

--- a/src/main/java/com/petmatz/domain/pet/PetService.java
+++ b/src/main/java/com/petmatz/domain/pet/PetService.java
@@ -4,15 +4,13 @@ import com.petmatz.domain.pet.dto.PetSaveResponse;
 import com.petmatz.domain.pet.dto.PetServiceDto;
 import com.petmatz.domain.pet.dto.PetUpdateResponse;
 import com.petmatz.domain.user.entity.User;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.net.MalformedURLException;
-import java.util.Map;
 
 public interface PetService {
     PetServiceDto fetchPetInfo(String dogRegNo, String ownerNm); //외부 API를 호출하여 동물 등록 정보를 가져옵니다.
     PetSaveResponse savePet(User user, PetServiceDto dto) throws MalformedURLException;  //새로운 펫 정보를 저장합니다.
-    PetUpdateResponse updatePet(Long petId, User user, PetServiceDto updatedDto); //기존 펫 정보를 업데이트합니다.
+    PetUpdateResponse updatePet(Long petId, User user, PetServiceDto updatedDto) throws MalformedURLException; //기존 펫 정보를 업데이트합니다.
     void deletePet(Long petId, User user); //특정 펫 정보를 삭제합니다.
 }
 

--- a/src/main/java/com/petmatz/domain/pet/PetServiceImpl.java
+++ b/src/main/java/com/petmatz/domain/pet/PetServiceImpl.java
@@ -71,90 +71,40 @@ public class PetServiceImpl implements PetService{
             throw new PetServiceException(PetErrorCode.DOG_REG_NO_DUPLICATE);
         }
 
-        //6-1 Img 정제
-        //TODO 펫 구분하는거 ID로 못함. 딴걸로 해야 함.
         URL uploadURL = awsClient.uploadImg(user.getAccountId(), dto.profileImg(), "PET_IMG", dto.dogRegNo());
-        String imgURL = uploadURL.getProtocol() + "://" + uploadURL.getHost() + uploadURL.getPath();
-        String resultImgURL = String.valueOf(uploadURL);
-        if (dto.profileImg().startsWith("profile")) {
-            imgURL = uploadURL.getProtocol() + "://" + uploadURL.getHost() + "/기본이미지_폴더/" + dto.profileImg() + ".svg";
-            resultImgURL = "";
-        }
-        // DTO에서 Pet 엔티티 생성
-        Pet pet = Pet.builder()
-                .user(user)
-                .dogRegNo(dto.dogRegNo())
-                .petName(dto.petName())
-                .breed(dto.breed())
-                .gender(Gender.fromString(dto.gender()))
-                .neuterYn(dto.neuterYn())
-                .size(Size.fromString(dto.size()))
-                .age(dto.age())
-                .temperament(dto.temperament())
-                .preferredWalkingLocation(dto.preferredWalkingLocation())
-                .profileImg(imgURL)
-                .comment(dto.comment())
-                .build();
+        String profileImg = uploadURL.getProtocol() + "://" + uploadURL.getHost() + uploadURL.getPath();
 
+        if (dto.profileImg().startsWith("profile")) {
+            profileImg = uploadURL.getProtocol() + "://" + uploadURL.getHost() + "/기본이미지_폴더/" + dto.profileImg() + ".svg";
+        }
+
+        Pet pet = Pet.createFromDto(user, dto, profileImg);
         Long id = repository.save(pet).getId();
 
-        // User의 isRegistered 상태 업데이트
         user.markAsRegistered();
         userRepository.save(user);
 
-        return PetSaveResponse.of(id, resultImgURL);
+        return PetSaveResponse.of(id, profileImg);
     }
 
     // 펫 업데이트
-    public PetUpdateResponse updatePet(Long petId, User user, PetServiceDto updatedDto) {
+    public PetUpdateResponse updatePet(Long petId, User user, PetServiceDto updatedDto) throws MalformedURLException {
         Pet existingPet = repository.findByIdAndUser(petId, user)
                 .orElseThrow(() -> new PetServiceException(PetErrorCode.PET_NOT_FOUND));
 
-        String UUID = updatedDto.dogRegNo();
-
-        // 현재 사용자가 리소스 소유자인지 검증
-        if (!existingPet.getUser().equals(user)) {
-            throw new SecurityException("권한이 없습니다.");
-        }
-
-        try {
-
-            String imgURL = updatedDto.profileImg();
-            String resultImgURL = "";
-            if (!existingPet.checkImgURL(updatedDto.profileImg())) {
-                //6-1 Img 정제
-                URL uploadURL = awsClient.uploadImg(user.getAccountId(), updatedDto.profileImg(), "PET_IMG", existingPet.getDogRegNo());
-                imgURL = uploadURL.getProtocol() + "://" + uploadURL.getHost() + uploadURL.getPath();
-                resultImgURL = String.valueOf(uploadURL);
-                if (updatedDto.profileImg().startsWith("profile")) {
-                    imgURL = uploadURL.getProtocol() + "://" + uploadURL.getHost() + "/기본이미지_폴더/" + updatedDto.profileImg() + ".svg";
-                    resultImgURL = "";
-                }
+        String profileImg = existingPet.getProfileImg();
+        if (!existingPet.checkImgURL(updatedDto.profileImg())) {
+            URL uploadURL = awsClient.uploadImg(user.getAccountId(), updatedDto.profileImg(), "PET_IMG", existingPet.getDogRegNo());
+            profileImg = uploadURL.getProtocol() + "://" + uploadURL.getHost() + uploadURL.getPath();
+            if (updatedDto.profileImg().startsWith("profile")) {
+                profileImg = uploadURL.getProtocol() + "://" + uploadURL.getHost() + "/기본이미지_폴더/" + updatedDto.profileImg() + ".svg";
             }
-            // 병합된 DTO를 기반으로 엔티티 생성
-            Pet updatedPet = Pet.builder()
-                    .id(existingPet.getId())
-                    .user(user)
-                    .dogRegNo(updatedDto.dogRegNo() != null ? updatedDto.dogRegNo() : existingPet.getDogRegNo())
-                    .petName(updatedDto.petName() != null ? updatedDto.petName() : existingPet.getPetName())
-                    .breed(updatedDto.breed() != null ? updatedDto.breed() : existingPet.getBreed())
-                    .gender(updatedDto.gender() != null ? Gender.fromString(updatedDto.gender()) : existingPet.getGender())
-                    .neuterYn(updatedDto.neuterYn() != null ? updatedDto.neuterYn() : existingPet.getNeuterYn())
-                    .size(updatedDto.size() != null ? Size.fromString(updatedDto.size()) : existingPet.getSize())
-                    .age(updatedDto.age() != null ? updatedDto.age() : existingPet.getAge())
-                    .temperament(updatedDto.temperament() != null ? updatedDto.temperament() : existingPet.getTemperament())
-                    .preferredWalkingLocation(updatedDto.preferredWalkingLocation() != null ? updatedDto.preferredWalkingLocation() : existingPet.getPreferredWalkingLocation())
-                    .profileImg(imgURL)
-                    .comment(updatedDto.comment() != null ? updatedDto.comment() : existingPet.getComment())
-                    .createdAt(existingPet.getCreatedAt())
-                    .petToPetMissions(existingPet.getPetToPetMissions())
-                    .build();
-
-            repository.save(updatedPet);
-            return PetUpdateResponse.of(UUID, resultImgURL);
-        } catch (Exception e) {
-            throw new PetServiceException(PetErrorCode.UPDATE_FAILED, "GENERAL_EXCEPTION");
         }
+
+        existingPet.updateFromDto(updatedDto, profileImg);
+        repository.save(existingPet);
+
+        return PetUpdateResponse.of(existingPet.getDogRegNo(), profileImg);
     }
 
 


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- 반려동물 정보 수정 API 리팩토링
- 중복 로직 제거 및 Pet.createFromDto, Pet.updateFromDto 메서드로 도메인 로직 위임
- 업로드 이미지 URL 생성 로직 간소화 및 공통 처리

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- PetServiceImpl.savePet, updatePet 내 중복된 Entity 생성/갱신 로직 → Pet 도메인으로 이동
- createFromDto, updateFromDto 메서드 신설
- 이미지 URL 생성 로직 개선
- profileImg 이름이 "profile"로 시작하는 경우 기본 이미지로 처리
- PetController.updatePet에 throws MalformedURLException 명시
- 필요 없는 변수 제거 (resultImgURL, UUID, 불필요한 try-catch 등)
- PetService 인터페이스 메서드 시그니처 정리
